### PR TITLE
Add abi3audit check for stable ABI violations to CI

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -60,3 +60,10 @@ jobs:
         python -m pip install --find-links=dist/ nanobind_example
         python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
       working-directory: ${{ github.workspace }}/nanobind_example
+    - name: Check ${{ matrix.os }} CPython>=3.12 wheels for stable ABI violations
+      if: matrix.py == '3.12'
+      run: |
+        python -m pip install --upgrade abi3audit
+        python -m abi3audit dist/*.whl
+      shell: bash
+      working-directory: ${{ github.workspace }}/nanobind_example


### PR DESCRIPTION
Only applies to CPython>=3.12.