### PR TITLE
Make static linking for `nanobind_extension` optional

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -15,7 +15,7 @@ load("@nanobind_bazel//:helpers.bzl", "extension_name")
 
 NANOBIND_COPTS = select({
     Label("@rules_cc//cc/compiler:msvc-cl"): [],
-    "//conditions:default": ["-fexceptions", "-fvisibility=hidden"],
+    "//conditions:default": ["-fexceptions", "-fno-strict-aliasing"],
 })
 
 NANOBIND_FEATURES = [
@@ -31,8 +31,10 @@ NANOBIND_DEPS = [
 # A C++ Python extension library built with nanobind.
 # Given a name $NAME, defines the following targets:
 # 1. $NAME.so, a shared object library for use on Linux/Mac.
-# 2. $NAME.pyd, a copy of $NAME.so for use on Windows.
-# 3. $NAME, an alias pointing to the appropriate library
+# 2. $NAME.abi3.so, a copy of $NAME.so for Linux/Mac,
+#     indicating that it is compatible with the Python stable ABI.
+# 3. $NAME.pyd, a copy of $NAME.so for use on Windows.
+# 4. $NAME, an alias pointing to the appropriate library
 #    depending on the target platform.
 def nanobind_extension(
         name,

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -49,8 +49,7 @@ def nanobind_extension(
         copts = copts + NANOBIND_COPTS,
         features = features + NANOBIND_FEATURES,
         deps = deps + NANOBIND_DEPS,
-        linkshared = True,
-        linkstatic = True,
+        linkshared = True,  # Python extensions need to be shared libs.
         **kwargs
     )
 

--- a/helpers.bzl
+++ b/helpers.bzl
@@ -14,7 +14,7 @@ def sizedefs():
     })
 
 # Define the Python version hex if stable ABI builds are requested.
-def pyversionhex():
+def py_limited_api():
     return select({
         "@nanobind_bazel//:cp312": ["Py_LIMITED_API=0x030C0000"],
         "@nanobind_bazel//:cp313": ["Py_LIMITED_API=0x030D0000"],

--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -22,6 +22,7 @@ def _internal_configure_extension_impl(module_ctx):
         name = "robin_map",
         build_file = "//:robin_map.BUILD",
         strip_prefix = "robin-map-1.2.1",
+        integrity = "sha256-K1TSwd4vc76lxR1dy9ZIE6CMrxv93P3u5Aq3TpWZ6OM=",
         urls = ["https://github.com/Tessil/robin-map/archive/refs/tags/v1.2.1.tar.gz"],
     )
 

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -29,7 +29,7 @@ cc_library(
             "-flto",
         ],
     }) + sizeopts(),
-    defines = ["NB_SHARED=1"] + py_limited_api(),
+    defines = py_limited_api(),
     includes = ["include"],
     linkopts = select({
         "@rules_cc//cc/compiler:msvc-cl": ["/LTCG"],  # MSVC.

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -38,47 +38,22 @@ cc_library(
         "//conditions:default": [
             "-fexceptions",
             "-flto",
+            "-fno-strict-aliasing",
         ],
     }) + sizeopts(),
     defines = py_limited_api(),
     includes = ["include"],
     linkopts = select({
-        "@rules_cc//cc/compiler:msvc-cl": ["/LTCG"],  # MSVC.
-        "@platforms//os:macos": [
-            "-Wl,@$(location :cmake/darwin-ld-cpython.sym)",  # Apple.
-        ],
-        "//conditions:default": [],
-    }),
-    local_defines = sizedefs(),  # sizeopts apply to nanobind only.
-    textual_hdrs = glob(
-        [
-            "include/**/*.h",
-            "src/*.h",
-        ],
-    ),
-    deps = _NB_DEPS,
-)
-
-cc_library(
-    name = "libnanobind-static",
-    copts = select({
-        "@rules_cc//cc/compiler:msvc-cl": [],
-        "//conditions:default": [
-            "-fvisibility=hidden",
-            "-fno-strict-aliasing",
-        ],
-    }),
-    defines = py_limited_api(),
-    linkopts = select({
         "@platforms//os:linux": [
-            "--Wl,--gc-sections",
+            "-Wl,--gc-sections",
         ],
         "@platforms//os:macos": [
             "-Wl,@$(location :cmake/darwin-ld-cpython.sym)",  # Apple.
             "-Wl,-dead_strip",
         ],
+        "@rules_cc//cc/compiler:msvc-cl": ["/LTCG"],  # MSVC.
+        "//conditions:default": [],
     }),
-    linkstatic = True,
     local_defines = sizedefs(),  # sizeopts apply to nanobind only.
     textual_hdrs = glob(
         [

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -11,6 +11,17 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
+_NB_DEPS = [
+    "@robin_map",
+    "@rules_python//python/cc:current_py_cc_headers",
+] + select({
+    # we need to link in the Python libs only on Windows to signal to the linker that it
+    # needs to go searching for these symbols at runtime.
+    # TODO: This seems Windows-specific, so change to `@platforms//os:windows`?
+    "@rules_cc//cc/compiler:msvc-cl": ["@rules_python//python/cc:current_py_cc_libs"],
+    "//conditions:default": [],
+})
+
 cc_library(
     name = "nanobind",
     srcs = glob(["src/*.cpp"]),
@@ -45,10 +56,7 @@ cc_library(
             "src/*.h",
         ],
     ),
-    deps = [
-        "@robin_map",
-        "@rules_python//python/cc:current_py_cc_headers",
-    ],
+    deps = _NB_DEPS,
 )
 
 cc_library(
@@ -78,8 +86,5 @@ cc_library(
             "src/*.h",
         ],
     ),
-    deps = [
-        "@robin_map",
-        "@rules_python//python/cc:current_py_cc_headers",
-    ],
+    deps = _NB_DEPS,
 )


### PR DESCRIPTION
Results in a `@nanobind//:libnanobind` target producing a `libnanobind.a` file.