### PR TITLE
Remove version parsing from `nanobind_bazel`, pin fixed version instead

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "nanobind_bazel",
-    version = "1.8.0",
+    version = "0.1.0",
 )
 
 bazel_dep(name = "platforms", version = "0.0.8")

--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -1,41 +1,29 @@
 """
 Module extension for configuring nanobind_bazel.
-
-Used exactly as in pybind11_bazel.
+Pins nanobind and robin-map to a specific version.
+To override versions, use a `git_override` of nanobind-bazel,
+and patch the version and integrity parameter of the `http_archive`s below.
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def _parse_my_own_version_from_module_dot_bazel(module_ctx):
-    lines = module_ctx.read(Label("//:MODULE.bazel")).split("\n")
-    for line in lines:
-        parts = line.split("\"")
-        if parts[0] == "    version = ":
-            return parts[1]
-    fail("Failed to parse my own version from `MODULE.bazel`.")
-
-def _internal_configure_extension_impl(module_ctx):
-    version = _parse_my_own_version_from_module_dot_bazel(module_ctx)
-
-    # Pin robin-map to its latest stable tag unconditionally.
+def _internal_configure_extension_impl(_):
+    robin_map_version = "1.2.1"
     http_archive(
         name = "robin_map",
         build_file = "//:robin_map.BUILD",
-        strip_prefix = "robin-map-1.2.1",
+        strip_prefix = "robin-map-%s" % robin_map_version,
         integrity = "sha256-K1TSwd4vc76lxR1dy9ZIE6CMrxv93P3u5Aq3TpWZ6OM=",
-        urls = ["https://github.com/Tessil/robin-map/archive/refs/tags/v1.2.1.tar.gz"],
+        urls = ["https://github.com/Tessil/robin-map/archive/refs/tags/v%s.tar.gz" % robin_map_version],
     )
 
-    # TODO: Allow commit hashes here, and mention how to include commits
-    # TODO: in README.
-    # Handle updated tags in the Bazel Central Registry, which are suffixed with ".bzl.$N",
-    # where N is the revision number.
-    version = version.split(".bzl.")[0]
+    nanobind_version = "1.9.2"
     http_archive(
         name = "nanobind",
         build_file = "//:nanobind.BUILD",
-        strip_prefix = "nanobind-%s" % version,
-        urls = ["https://github.com/wjakob/nanobind/archive/v%s.zip" % version],
+        strip_prefix = "nanobind-%s" % nanobind_version,
+        integrity = "sha256-FJo9pAsKmIUT2M9ecdswNzc4I1BaPJL4e5iMktfgqzQ=",
+        urls = ["https://github.com/wjakob/nanobind/archive/refs/tags/v%s.tar.gz" % nanobind_version],
     )
 
 internal_configure_extension = module_extension(implementation = _internal_configure_extension_impl)


### PR DESCRIPTION
In response to a recent issue on versioning ideas for nanobind-bazel. The way to change versions is now to use a `git_override`.