### PR TITLE
Remove default LTO options, dead_strip in MacOS linker options

### DIFF
--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -14,13 +14,7 @@ package(default_visibility = ["//visibility:public"])
 _NB_DEPS = [
     "@robin_map",
     "@rules_python//python/cc:current_py_cc_headers",
-] + select({
-    # we need to link in the Python libs only on Windows to signal to the linker that it
-    # needs to go searching for these symbols at runtime.
-    # TODO: This seems Windows-specific, so change to `@platforms//os:windows`?
-    "@rules_cc//cc/compiler:msvc-cl": ["@rules_python//python/cc:current_py_cc_libs"],
-    "//conditions:default": [],
-})
+]
 
 cc_library(
     name = "nanobind",

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -31,13 +31,11 @@ cc_library(
     }),
     copts = select({
         "@rules_cc//cc/compiler:msvc-cl": [
-            "/EHsc",  # exceptions
-            "/GL",  # LTO / whole program optimization
+            "/EHsc",  # exceptions.
         ],
         # clang and gcc, across all platforms.
         "//conditions:default": [
             "-fexceptions",
-            "-flto",
             "-fno-strict-aliasing",
         ],
     }) + sizeopts(),
@@ -49,9 +47,7 @@ cc_library(
         ],
         "@platforms//os:macos": [
             "-Wl,@$(location :cmake/darwin-ld-cpython.sym)",  # Apple.
-            "-Wl,-dead_strip",
         ],
-        "@rules_cc//cc/compiler:msvc-cl": ["/LTCG"],  # MSVC.
         "//conditions:default": [],
     }),
     local_defines = sizedefs(),  # sizeopts apply to nanobind only.


### PR DESCRIPTION
Follows the official documentation's guidance that LTO is not strictly necessary due to the library component. As an alternative, users can give the `thin_lto` feature to a nanobind_extension instead.

The second `-Wl,-dead_strip` removal is due to it appearing twice in the generated linker command. I also saw a missing symbol error during a stubgen attempt earlier, which has since disappeared.