### PR TITLE
Add strip optimizations to linker flags

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -68,6 +68,25 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "WindowsReleaseBuild",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+    values = {
+        "compilation_mode": "opt",
+    },
+)
+
+selects.config_setting_group(
+    name = "releaseBuild",
+    match_any = [
+        ":LinuxReleaseBuild",
+        ":MacReleaseBuild",
+        ":WindowsReleaseBuild",
+    ],
+)
+
 selects.config_setting_group(
     name = "unix",
     match_any = [

--- a/BUILD
+++ b/BUILD
@@ -48,6 +48,26 @@ config_setting(
     flag_values = {":py-limited-api": "unset"},
 )
 
+config_setting(
+    name = "MacReleaseBuild",
+    constraint_values = [
+        "@platforms//os:macos",
+    ],
+    values = {
+        "compilation_mode": "opt",
+    },
+)
+
+config_setting(
+    name = "LinuxReleaseBuild",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+    values = {
+        "compilation_mode": "opt",
+    },
+)
+
 selects.config_setting_group(
     name = "unix",
     match_any = [

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -11,7 +11,7 @@ which can then be included e.g. as a `data` input in a ``native.py_library``.
 """
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@nanobind_bazel//:helpers.bzl", "extension_name", "sizeopts")
+load("@nanobind_bazel//:helpers.bzl", "extension_name", "nb_sizeopts")
 
 NANOBIND_COPTS = select({
     "@platforms//os:macos": [
@@ -27,7 +27,7 @@ NANOBIND_COPTS = select({
         "-fdata-sections",
     ],
     "//conditions:default": [],
-}) + sizeopts()
+}) + nb_sizeopts()
 
 NANOBIND_DEPS = [Label("@nanobind//:nanobind")]
 

--- a/helpers.bzl
+++ b/helpers.bzl
@@ -1,13 +1,13 @@
 """Helper flags for nanobind build options."""
 
-def sizeopts():
+def nb_sizeopts():
     return select({
         "@nanobind_bazel//:msvc_and_minsize": ["/Os"],
         "@nanobind_bazel//:nonmsvc_and_minsize": ["-Os"],
         "@nanobind_bazel//:without_sizeopts": [],
     })
 
-def stripopts():
+def nb_stripopts():
     """Linker options to strip external and debug symbols from nanobind release builds."""
     return select({
         "@nanobind_bazel//:MacReleaseBuild": ["-Wl,-x", "-Wl,-S"],
@@ -15,10 +15,10 @@ def stripopts():
         "//conditions:default": [],
     })
 
-def sizedefs():
+def maybe_compact_asserts():
     return select({
-        "@nanobind_bazel//:with_sizeopts": ["NB_COMPACT_ASSERTIONS"],
-        "@nanobind_bazel//:without_sizeopts": [],
+        "@nanobind_bazel//:releaseBuild": ["NB_COMPACT_ASSERTIONS"],
+        "//conditions:default": [],
     })
 
 # Define the Python version hex if stable ABI builds are requested.

--- a/helpers.bzl
+++ b/helpers.bzl
@@ -7,6 +7,14 @@ def sizeopts():
         "@nanobind_bazel//:without_sizeopts": [],
     })
 
+def stripopts():
+    """Linker options to strip external and debug symbols from nanobind release builds."""
+    return select({
+        "@nanobind_bazel//:MacReleaseBuild": ["-Wl,-x", "-Wl,-S"],
+        "@nanobind_bazel//:LinuxReleaseBuild": ["-Wl,-s"],
+        "//conditions:default": [],
+    })
+
 def sizedefs():
     return select({
         "@nanobind_bazel//:with_sizeopts": ["NB_COMPACT_ASSERTIONS"],

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -5,7 +5,7 @@ Size optimizations used: -Os, LTO.
 Linker optimizations used: LTO (clang, gcc) / LTCG (MSVC), linker response file (macOS only).
 """
 
-load("@nanobind_bazel//:helpers.bzl", "py_limited_api", "sizedefs", "sizeopts")
+load("@nanobind_bazel//:helpers.bzl", "py_limited_api", "sizedefs", "sizeopts", "stripopts")
 
 licenses(["notice"])
 
@@ -37,19 +37,14 @@ cc_library(
     features = ["-pic"],  # use a compiler flag instead.
     includes = ["include"],
     linkopts = select({
-        "@platforms//os:linux": [
-            "-Wl,-s",
-            "-Wl,--gc-sections",
-        ],
+        "@platforms//os:linux": ["-Wl,--gc-sections"],
         "@platforms//os:macos": [
             # chained fixups on Apple platforms.
             "-Wl,@$(location :cmake/darwin-ld-cpython.sym)",
             "-Wl,-dead_strip",
-            "-Wl,-x",
-            "-Wl,-S",
         ],
         "//conditions:default": [],
-    }),
+    }) + stripopts(),
     local_defines = sizedefs(),  # sizeopts apply to nanobind only.
     textual_hdrs = glob(
         [

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -26,6 +26,7 @@ cc_library(
         ],
         "@platforms//os:linux": [
             "-fPIC",
+            "-fvisibility=hidden",
             "-ffunction-sections",
             "-fdata-sections",
             "-fno-strict-aliasing",
@@ -37,11 +38,15 @@ cc_library(
     includes = ["include"],
     linkopts = select({
         "@platforms//os:linux": [
+            "-Wl,-s",
             "-Wl,--gc-sections",
         ],
         "@platforms//os:macos": [
             # chained fixups on Apple platforms.
             "-Wl,@$(location :cmake/darwin-ld-cpython.sym)",
+            "-Wl,-dead_strip",
+            "-Wl,-x",
+            "-Wl,-S",
         ],
         "//conditions:default": [],
     }),

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -2,10 +2,16 @@
 A cross-platform nanobind Bazel build.
 Supports size and linker optimizations across all three major operating systems.
 Size optimizations used: -Os, LTO.
-Linker optimizations used: LTO (clang, gcc) / LTCG (MSVC), linker response file (macOS only).
+Linker optimizations used: Debug stripping (release mode), linker response file (macOS only).
 """
 
-load("@nanobind_bazel//:helpers.bzl", "py_limited_api", "sizedefs", "sizeopts", "stripopts")
+load(
+    "@nanobind_bazel//:helpers.bzl",
+    "maybe_compact_asserts",
+    "nb_sizeopts",
+    "nb_stripopts",
+    "py_limited_api",
+)
 
 licenses(["notice"])
 
@@ -32,7 +38,7 @@ cc_library(
             "-fno-strict-aliasing",
         ],
         "//conditions:default": [],
-    }) + sizeopts(),
+    }) + nb_sizeopts(),
     defines = py_limited_api(),
     features = ["-pic"],  # use a compiler flag instead.
     includes = ["include"],
@@ -44,8 +50,8 @@ cc_library(
             "-Wl,-dead_strip",
         ],
         "//conditions:default": [],
-    }) + stripopts(),
-    local_defines = sizedefs(),  # sizeopts apply to nanobind only.
+    }) + nb_stripopts(),
+    local_defines = maybe_compact_asserts(),
     textual_hdrs = glob(
         [
             "include/**/*.h",


### PR DESCRIPTION
Previously, mangled symbols would show up in the exports list on MacOS (as seen in `nm -U` commands on the Python bindings shared objects).

The fix here is to supply `-Wl,-x` and `-Wl,-S` to the macOS linker, which ends up producing the same output as CMake does (verified on my machine).

Similarly, after checking the Linux ninja build manifest, Linux needs a `-Wl,-s`.