### PR TITLE
Refactor common build opts, build robin_map without -fexceptions

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -11,24 +11,14 @@ which can then be included e.g. as a `data` input in a ``native.py_library``.
 """
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@nanobind_bazel//:helpers.bzl", "extension_name", "nb_sizeopts")
+load(
+    "@nanobind_bazel//:helpers.bzl",
+    "extension_name",
+    "nb_common_opts",
+    "nb_sizeopts",
+)
 
-NANOBIND_COPTS = select({
-    "@platforms//os:macos": [
-        "-fPIC",
-        "-fvisibility=hidden",
-        "-fno-stack-protector",
-    ],
-    "@platforms//os:linux": [
-        "-fPIC",
-        "-fvisibility=hidden",
-        "-fno-stack-protector",
-        "-ffunction-sections",
-        "-fdata-sections",
-    ],
-    "//conditions:default": [],
-}) + nb_sizeopts()
-
+NANOBIND_COPTS = nb_common_opts() + nb_sizeopts()
 NANOBIND_DEPS = [Label("@nanobind//:nanobind")]
 
 def nanobind_extension(

--- a/helpers.bzl
+++ b/helpers.bzl
@@ -1,5 +1,22 @@
 """Helper flags for nanobind build options."""
 
+def nb_common_opts(mode = "user"):
+    unix_common_opts = [
+        "-fPIC",
+        "-fvisibility=hidden",
+        "-fno-strict-aliasing",
+    ]
+
+    if mode == "user":
+        # user-facing code gets stack smashing protection
+        # disable flag.
+        unix_common_opts.append("-fno-stack-protector")
+
+    return select({
+        "@nanobind_bazel//:unix": unix_common_opts,
+        "//conditions:default": [],
+    })
+
 def nb_sizeopts():
     return select({
         "@nanobind_bazel//:msvc_and_minsize": ["/Os"],

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -8,6 +8,7 @@ Linker optimizations used: Debug stripping (release mode), linker response file 
 load(
     "@nanobind_bazel//:helpers.bzl",
     "maybe_compact_asserts",
+    "nb_common_opts",
     "nb_sizeopts",
     "nb_stripopts",
     "py_limited_api",
@@ -24,23 +25,8 @@ cc_library(
         "@platforms//os:macos": [":cmake/darwin-ld-cpython.sym"],
         "//conditions:default": [],
     }),
-    copts = select({
-        "@platforms//os:macos": [
-            "-fPIC",
-            "-fvisibility=hidden",
-            "-fno-strict-aliasing",
-        ],
-        "@platforms//os:linux": [
-            "-fPIC",
-            "-fvisibility=hidden",
-            "-ffunction-sections",
-            "-fdata-sections",
-            "-fno-strict-aliasing",
-        ],
-        "//conditions:default": [],
-    }) + nb_sizeopts(),
+    copts = nb_common_opts(mode = "library") + nb_sizeopts(),
     defines = py_limited_api(),
-    features = ["-pic"],  # use a compiler flag instead.
     includes = ["include"],
     linkopts = select({
         "@platforms//os:linux": ["-Wl,--gc-sections"],

--- a/robin_map.BUILD
+++ b/robin_map.BUILD
@@ -4,10 +4,12 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "robin_map",
-    hdrs = glob([
-        "include/tsl/*.h",
-    ]),
-    copts = ["-fexceptions"],
-    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
+    hdrs = [
+        "include/tsl/robin_growth_policy.h",
+        "include/tsl/robin_hash.h",
+        "include/tsl/robin_map.h",
+        "include/tsl/robin_set.h",
+    ],
+    includes = ["."],
     strip_include_prefix = "include",
 )


### PR DESCRIPTION
`-fexceptions` seems to be the default for gcc and clang, anyways.

The common options are factored out into a new helper function, with the option of a `mode` argument, which is either user-facing (the default, adds `-fno-stack-protector` on Unix systems) or lib-facing (no-op).