### PR TITLE
Update nanobind to v2.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,10 +4,10 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_python", version = "0.31.0")
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "rules_python", version = "0.32.2")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
 
 # Creates a `http_archive` for nanobind and robin-map.
 internal_configure = use_extension("//:internal_configure.bzl", "internal_configure_extension")

--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -8,21 +8,21 @@ and patch the version and integrity parameter of the `http_archive`s below.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _internal_configure_extension_impl(_):
-    robin_map_version = "1.2.1"
+    robin_map_version = "1.3.0"
     http_archive(
         name = "robin_map",
         build_file = "//:robin_map.BUILD",
         strip_prefix = "robin-map-%s" % robin_map_version,
-        integrity = "sha256-K1TSwd4vc76lxR1dy9ZIE6CMrxv93P3u5Aq3TpWZ6OM=",
+        integrity = "sha256-qEJK07Cv/UxX7Sbw89iilgTw4fLvIIn0l/YUsclMcjY=",
         urls = ["https://github.com/Tessil/robin-map/archive/refs/tags/v%s.tar.gz" % robin_map_version],
     )
 
-    nanobind_version = "1.9.2"
+    nanobind_version = "2.0.0"
     http_archive(
         name = "nanobind",
         build_file = "//:nanobind.BUILD",
         strip_prefix = "nanobind-%s" % nanobind_version,
-        integrity = "sha256-FJo9pAsKmIUT2M9ecdswNzc4I1BaPJL4e5iMktfgqzQ=",
+        integrity = "sha256-LnBydITtt6hkXSb2qfZzUqZoZXw03npgO/nGjly/j/k=",
         urls = ["https://github.com/wjakob/nanobind/archive/refs/tags/v%s.tar.gz" % nanobind_version],
     )
 

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -20,7 +20,10 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "nanobind",
-    srcs = glob(["src/*.cpp"]),
+    srcs = glob(
+        include = ["src/*.cpp"],
+        exclude = ["src/nb_combined.cpp"],
+    ),
     additional_linker_inputs = select({
         "@platforms//os:macos": [":cmake/darwin-ld-cpython.sym"],
         "//conditions:default": [],


### PR DESCRIPTION
Changes needed to make the upgrade work:

1) Bump robin-map to v1.3.0. This is due to the added API `erase_fast(iterator pos)`
contributed to robin-map that is used in nanobind to avoid expensive lookups in hashmaps.
2) Bump nanobind to v2.0.0. I had to exclude the `nb_combined.cpp` file to fix a
compilation error when building libnanobind.

Also includes some core dependency updates in fff5a8486806d5a829580014478f8b9c12cd607d.

Addresses #26.

Source thread for the robin-map change is in https://github.com/Tessil/robin-map/pull/76, backstory is contained in https://github.com/wjakob/nanobind/issues/507 and references therein.