### PR TITLE
Prepare v2.0.0 release of nanobind-bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "nanobind_bazel",
-    version = "1.0.0",
-    compatibility_level = 1,
+    version = "2.0.0",
+    compatibility_level = 2,
 )
 
 bazel_dep(name = "platforms", version = "0.0.10")


### PR DESCRIPTION
Increases the compatibility level to 2 after the major version bump in nanobind.