### PR TITLE
Add `nanobind_shared_library` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Here's the full list of exported rules:
 - `nanobind_extension`, building a Python extension containing the bindings as a `*.so` file.
 These extensions can be used e.g. as a `data` dependency for a `py_library` target.
 - `nanobind_library`, a C++ library target that can be used as a dependency of a `nanobind_extension`. Directly forwards its arguments to the `cc_library` rule.
+- `nanobind_shared_library`, a C++ shared library target that can be used to
+produce smaller objects in scenarios with multiple independent bindings extensions. Directly forwards its arguments to the `cc_shared_library` rule.
 - `nanobind_test`, a C++ test for a `nanobind_library`. Forwards its argument to a `cc_test`.
 
 Each target is given nanobind's specific build flags, optimizations and dependencies.
@@ -31,7 +33,7 @@ In contrast to that project, though, nanobind does not support Python interprete
 
 - [x] First successful test, e.g. on wjakob's [nanobind example](https://github.com/wjakob/nanobind_example).
 - [x] A BCR release.
-- [ ] A `nanobind_shared_library` target for a `cc_shared_library` using (lib)nanobind.
+- [x] A `nanobind_shared_library` target for a `cc_shared_library` using (lib)nanobind.
 - [ ] Supporting custom nanobind build targets instead of the internal one.
 
 ## Contributing

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -111,6 +111,36 @@ def nanobind_library(
         **kwargs
     )
 
+def nanobind_shared_library(
+        name,
+        deps = [],
+        **kwargs):
+    """A shared library containing nanobind as a static dependency.
+
+    Using a shared nanobind library is useful when partitioning C++ binding
+    code over multiple extensions, where linking all of them statically would
+    produce much larger bindings than necessary.
+
+    Args:
+        name: str
+            A name for this target. On Linux/MacOS, the target name determines
+            the name of the resulting shared object file via lib${name}.so, e.g.
+            a `cc_shared_library(name = "nanobind-tensorflow")` produces the
+            shared object file libnanobind-tensorflow.so.
+        deps: list
+            A list of static dependencies for this shared library. By default,
+            a statically built nanobind is included.
+        **kwargs: Any
+            Additional keyword arguments passed directly to the `cc_shared_library`
+            rule. For a comprehensive list, see the Bazel documentation at
+            https://bazel.build/reference/be/c-cpp#cc_shared_library.
+    """
+    native.cc_shared_library(
+        name = name,
+        deps = deps + NANOBIND_DEPS,
+        **kwargs
+    )
+
 def nanobind_test(
         name,
         copts = [],


### PR DESCRIPTION
Equivalent to a native `cc_shared_library` with a static nanobind dependency.

This target enables linking multiple extensions with a single shared nanobind target, producing smaller binding sizes.

Closes #25.

Still TODO: Avoid auto-injection of `@nanobind` into the `nanobind_extension` deps, so that we don't link nanobind multiple times.

Reviews and opinions welcome.