### PR TITLE
Expose nanobind's stubgen as a `py_binary`

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -37,33 +37,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         py: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v4
-      with:
-        path: nanobind-bazel
-    - name: Set up Python ${{ matrix.py }} on ${{ matrix.os }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.py }}
-    - name: Check out nanobind example repo
-      uses: actions/checkout@v4
-      with:
-        repository: wjakob/nanobind_example
-        path: nanobind_example
-        ref: bazel
+      - uses: actions/checkout@v4
+        with:
+          path: nanobind-bazel
+      - name: Set up Python ${{ matrix.py }} on ${{ matrix.os }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+      - name: Check out nanobind example repo
+        uses: actions/checkout@v4
+        with:
+          repository: wjakob/nanobind_example
+          path: nanobind_example
+          ref: bazel
 
-    - name: Build and test nanobind_example on ${{ matrix.os }}
-      run: |
-        python -m pip wheel . -w dist
-        python -m pip install --find-links=dist/ nanobind_example
-        python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
-      working-directory: ${{ github.workspace }}/nanobind_example
-    - name: Check ${{ matrix.os }} CPython>=3.12 wheels for stable ABI violations
-      if: matrix.py == '3.12'
-      run: |
-        python -m pip install --upgrade abi3audit
-        python -m abi3audit dist/*.whl --verbose
-      shell: bash
-      working-directory: ${{ github.workspace }}/nanobind_example
+      - name: Build and test nanobind_example on ${{ matrix.os }}
+        run: |
+          python -m pip wheel . -w dist
+          python -m pip install --find-links=dist/ nanobind_example
+          python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
+        working-directory: ${{ github.workspace }}/nanobind_example
+      - name: Check ${{ matrix.os }} CPython>=3.12 wheels for sqtable ABI violations
+        if: matrix.py == '3.12'
+        run: |
+          python -m pip install --upgrade abi3audit
+          python -m abi3audit dist/*.whl --verbose
+        shell: bash
+        working-directory: ${{ github.workspace }}/nanobind_example

--- a/BUILD
+++ b/BUILD
@@ -149,3 +149,10 @@ selects.config_setting_group(
         ":with_sizeopts",
     ],
 )
+
+py_binary(
+    name = "nanobind_stubgen",
+    srcs = ["@nanobind//:src/stubgen.py"],
+    main = "@nanobind//:src/stubgen.py",
+    deps = ["@pypi__typing_extensions//:lib"],
+)

--- a/BUILD
+++ b/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])
 exports_files([
     "LICENSE",
     "pybind11_bazel.LICENSE",
+    "stubgen_wrapper.py",
 ])
 
 bool_flag(
@@ -148,11 +149,4 @@ selects.config_setting_group(
         ":nonmsvc",
         ":with_sizeopts",
     ],
-)
-
-py_binary(
-    name = "nanobind_stubgen",
-    srcs = ["@nanobind//:src/stubgen.py"],
-    main = "@nanobind//:src/stubgen.py",
-    deps = ["@pypi__typing_extensions//:lib"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,4 +11,4 @@ bazel_dep(name = "bazel_skylib", version = "1.6.1")
 
 # Creates a `http_archive` for nanobind and robin-map.
 internal_configure = use_extension("//:internal_configure.bzl", "internal_configure_extension")
-use_repo(internal_configure, "nanobind")
+use_repo(internal_configure, "nanobind", "pypi__typing_extensions")

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -162,9 +162,9 @@ def nanobind_stubgen(
             Label of the extension module for which the stub file should be
             generated.
         output_file: str or None
-            Output file path for the generated stub. If none is given, the
-            stub will be placed under the same location as the module in
-            your source tree.
+            Output file path for the generated stub, relative to $(BINDIR).
+            If none is given, the stub will be placed under the same location
+            as the module in your source tree.
         imports: list
             List of modules to import for stub generation.
         pattern_file: str or None
@@ -173,7 +173,7 @@ def nanobind_stubgen(
             https://nanobind.readthedocs.io/en/latest/typing.html#pattern-files.
         marker_file: str or None
             An empty typing marker file to add to the project, most often named
-            "py.typed".
+            "py.typed". Must be given relative to your Python project root.
         include_private_members: bool
             Whether to include private module members, i.e. those starting and/or
             ending with an underscore ("_").
@@ -181,6 +181,7 @@ def nanobind_stubgen(
             Whether to exclude all docstrings of all module members from the generated
             stub file.
     """
+    # TODO: Expose envs and deps targets to allow marker and pattern files
 
     NB_STUBGEN = Label("@nanobind//:stubgen")
     STUBGEN_WRAPPER = Label("@nanobind_bazel//:stubgen_wrapper.py")
@@ -193,13 +194,13 @@ def nanobind_stubgen(
     # declared by a rule beforehand. This might not be the
     # case for a generated stub, so we just give the raw name here
     if output_file:
-        args.append("-o $(BINDIR)/{}".format(output_file))
+        args.append("-o {}".format(output_file))
 
     # add pattern and marker files
     if pattern_file:
         args.append("-p " + loc.format(pattern_file))
     if marker_file:
-        args.append("-M " + loc.format(marker_file))
+        args.append("-M {}".format(marker_file))
 
     if include_private_members:
         args.append("--include-private")

--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -26,4 +26,12 @@ def _internal_configure_extension_impl(_):
         urls = ["https://github.com/wjakob/nanobind/archive/refs/tags/v%s.tar.gz" % nanobind_version],
     )
 
+    typing_extensions_version = "4.12.2"
+    http_archive(
+        name = "pypi__typing_extensions",
+        build_file = "//:typing_extensions.BUILD",
+        strip_prefix = "typing_extensions-%s" % typing_extensions_version,
+        urls = ["https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-%s.tar.gz" % typing_extensions_version],
+    )
+
 internal_configure_extension = module_extension(implementation = _internal_configure_extension_impl)

--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -31,6 +31,7 @@ def _internal_configure_extension_impl(_):
         name = "pypi__typing_extensions",
         build_file = "//:typing_extensions.BUILD",
         strip_prefix = "typing_extensions-%s" % typing_extensions_version,
+        integrity = "sha256-Gn6tVcflWd1N7ohW46iLQSJav+HOjfV7fBORX+Eh/7g=",
         urls = ["https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-%s.tar.gz" % typing_extensions_version],
     )
 

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -52,3 +52,5 @@ cc_library(
         "@rules_python//python/cc:current_py_cc_headers",
     ],
 )
+
+exports_files(["src/stubgen.py"])

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -53,4 +53,9 @@ cc_library(
     ],
 )
 
-exports_files(["src/stubgen.py"])
+py_library(
+    name = "stubgen",
+    srcs = ["src/stubgen.py"],
+    imports = ["src"],
+    deps = ["@pypi__typing_extensions//:lib"],
+)

--- a/stubgen_wrapper.py
+++ b/stubgen_wrapper.py
@@ -1,0 +1,112 @@
+import os
+import sys
+
+from pathlib import Path
+from typing import Union
+
+from stubgen import main
+from python.runfiles import runfiles
+
+DEBUG = bool(os.getenv("DEBUG", False))
+
+
+def get_runfiles_dir(path: Union[str, os.PathLike]):
+    ppath = Path(path)
+    for p in ppath.parents:
+        if p.parts[-1].endswith("runfiles"):
+            return p
+    raise RuntimeError("could not locate runfiles directory")
+
+
+def get_bindir(path: Union[str, os.PathLike]):
+    ppath = Path(path)
+    for p in ppath.parents:
+        if p.parts[-1].endswith("bin"):
+            return p
+    raise RuntimeError("could not locate $(BINDIR)")
+
+
+def convert_path_to_module(path: Union[str, os.PathLike]):
+    """
+    Converts a shared object file name to a Python module name
+    understood by importlib.
+
+    Example:
+        For a shared lib pkg/foo.so, this returns pkg.foo.
+    """
+    pp = Path(path)
+    # this trick strips up to two extensions from the file name.
+    # Since possible extensions at this point are
+    # .so, .abi3.so, and .pyd, this path always gives us the
+    # name of the shared lib without any extension.
+    extless = pp.with_name(pp.with_suffix("").stem)
+    # TODO: Normalize to snakecase
+    return ".".join(extless.parts)
+
+
+def wrapper():
+    """
+    A small wrapper to convert nanobind extension targets to module names
+    relative to the runfiles directory.
+
+    nanobind's stubgen script can only deal with module names
+    found on PYTHONPATH. Since Make variable expansion in Bazel
+    only works for paths, this does us no good.
+
+    The target extension and output file should be figured out directly
+    from the user's nanobind_stubgen rule definition - in fact, making
+    the user fiddle with rules is error-prone and unhelpful if they
+    have no Bazel experience.
+
+    Goes through the script's argv, finds the module name(s),
+    and converts each of them to a valid Python 3 module name.
+    """
+    script, *args = sys.argv
+    runfiles_dir = get_runfiles_dir(script)
+    bindir = get_bindir(script)
+    if DEBUG:
+        print(f"runfiles_dir = {runfiles_dir}")
+        print(f"bindir = {bindir}")
+    fname = ""
+    for i, arg in enumerate(args):
+       if arg.startswith("-m"):
+           fname = args.pop(i + 1)
+           if not fname.endswith((".so", ".pyd")):
+               raise ValueError(
+                   f"invalid extension file {fname!r}: "
+                   "only shared object files with extensions "
+                   ".so, .abi3.so, or .pyd are supported"
+               )
+           modname = convert_path_to_module(fname)
+           args.insert(i + 1, modname)
+
+    if "-o" not in args:
+        ext_path = runfiles_dir / fname
+        if DEBUG:
+            print(f"ext_path = {ext_path}")
+        if (ext_path).is_symlink():
+            # Path.readlink() is available on Python 3.9+ only.
+            objfile = Path(os.readlink(ext_path))
+            stub_outpath = objfile.with_suffix("").with_suffix(".pyi")
+            if DEBUG:
+                print(f"stub_outpath = {stub_outpath}")
+        else:
+            raise RuntimeError("could not locate original path to object file")
+
+        args.extend(["-o", str(stub_outpath)])
+    else:
+        # we have an output file, use its path instead relative to $(BINDIR),
+        # but in absolute form.
+        idx = args.index("-o")
+        args[idx + 1] = str(bindir / args[idx + 1])
+
+    if "-M" in args:
+        # fix up the path to the marker file relative to $(BINDIR).
+        idx = args.index("-M")
+        args[idx + 1] = str(bindir / args[idx + 1])
+
+    main(args)
+
+
+if __name__ == "__main__":
+    wrapper()

--- a/typing_extensions.BUILD
+++ b/typing_extensions.BUILD
@@ -1,0 +1,38 @@
+"""
+A version of the Python sdist Bazel template found in
+https://github.com/bazelbuild/rules_python/blob/main/python/private/pypi/deps.bzl ,
+specialized on the ``typing_extensions`` package.
+
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "lib",
+    srcs = ["src/typing_extensions.py"],
+    data = [
+        "CHANGELOG.md",
+        "LICENSE",
+        "PKG-INFO",
+        "README.md",
+        "pyproject.toml",
+    ],
+    # This makes the source directory a top-level in the Python import
+    # search path for anything that depends on this.
+    imports = ["src"],
+)


### PR DESCRIPTION
Adds `typing_extensions` as a unconditional dependency for the stubgen target.

The plan is to wrap the `py_binary` into a nanobind stubgen rule that lives in the same file as all other rules.

Closes #14.