### PR TITLE
Revert rules_cc bump

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,8 +5,8 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_cc", version = "0.0.10")
-bazel_dep(name = "rules_python", version = "0.36.0")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_python", version = "0.37.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 
 # Creates a `http_archive` for nanobind and robin-map.


### PR DESCRIPTION
It broke Bazel 6.x compatibility, and was not required.

rules_python@0.37.0 is now depended on for Python 3.13 support, which is good to have for free-threading (the headline feature of nanobind v2.2.0).