### PR TITLE
Add CPython 3.13 to CI test matrix

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        py: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        py: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,6 +47,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
+      - run: python -m pip install build
       - name: Check out nanobind example repo
         uses: actions/checkout@v4
         with:
@@ -56,12 +57,12 @@ jobs:
 
       - name: Build and test nanobind_example on ${{ matrix.os }}
         run: |
-          python -m pip wheel . -w dist
+          python -m build . -w
           python -m pip install --find-links=dist/ nanobind_example
           python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
         working-directory: ${{ github.workspace }}/nanobind_example
-      - name: Check ${{ matrix.os }} CPython>=3.12 wheels for sqtable ABI violations
-        if: matrix.py == '3.12'
+      - name: Check ${{ matrix.os }} CPython>=3.12 wheels for stable ABI violations
+        if: matrix.py >= 3.12
         run: |
           python -m pip install --upgrade abi3audit
           python -m abi3audit dist/*.whl --verbose


### PR DESCRIPTION
Also contains minor other tweaks, such as using build as a build frontend, and checking built wheels for CPython>=3.12 from now on.

-----------

Needs an upstream change in the nanobind_example's setup.py file (or a toolchain declaration in MODULE.bazel).