### PR TITLE
ci: Patch MODULE.bazel in nanobind example

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -41,8 +41,6 @@ jobs:
         py: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: nanobind-bazel
       - name: Set up Python ${{ matrix.py }} on ${{ matrix.os }}
         uses: actions/setup-python@v5
         with:
@@ -55,6 +53,8 @@ jobs:
           path: nanobind_example
           ref: bazel
 
+      - name: Override nanobind_bazel pin in MODULE.bazel
+        run: python fixup_module_bazel.py ${{ github.workspace}}/nanobind_example
       - name: Build and test nanobind_example on ${{ matrix.os }}
         run: |
           python -m build . -w

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/keith/pre-commit-buildifier
-      rev: 7.3.1
+      rev: 7.3.1.1
       hooks:
       -   id: buildifier
       -   id: buildifier-lint

--- a/fixup_module_bazel.py
+++ b/fixup_module_bazel.py
@@ -1,0 +1,37 @@
+"""
+Redeclare a dependency on nanobind_bazel by overwriting the content of MODULE.bazel.
+
+Used in nanobind-bazel CI to test against development versions in pull requests.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# TODO: Support arbitrary paths in the template below
+_LOCAL_NANOBIND_BAZEL = """
+bazel_dep(name = "nanobind_bazel", version = "")
+local_path_override(
+    module_name = "nanobind_bazel",
+    path = "../",
+)
+"""
+
+
+def main():
+    bazel_project = Path(sys.argv[1])
+    module_bazel = bazel_project / "MODULE.bazel"
+    if not module_bazel.exists():
+        raise FileNotFoundError(module_bazel)
+
+    content = module_bazel.read_text()
+    module_bazel.write_text(
+        re.sub(
+            r"bazel_dep\(name = \"nanobind_bazel\", version = [\w\".]*\)",
+            _LOCAL_NANOBIND_BAZEL,
+            content,
+        )
+    )
+
+if __name__ == "__main__":
+    main()

--- a/helpers.bzl
+++ b/helpers.bzl
@@ -50,7 +50,7 @@ def py_limited_api():
 # and stable ABI build yes/no.
 def extension_name(name):
     return select({
-        "@platforms//os:windows": name + ".pyd",
+        Label("@platforms//os:windows"): name + ".pyd",
         "@nanobind_bazel//:stable-abi-unix": name + ".abi3.so",
         "@nanobind_bazel//:unstable-abi-unix": name + ".so",
     })


### PR DESCRIPTION
Done via a small Python script for portability. This ensures that we test the nanobind example build against the latest version in CI.