### PR TITLE
Fix job skip condition by interpreting Python version as int

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -47,15 +47,16 @@ jobs:
       - name: Override nanobind_bazel pin in MODULE.bazel
         run: python fixup_module_bazel.py ${{ github.workspace}}/nanobind_example
       - name: Build and test nanobind_example on ${{ matrix.os }}
+        # --no-sync is required so that uv does not remove the .so file again.
         run: |
           uv sync --no-editable
-          uv run python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
+          uv run --no-sync -- python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
         working-directory: ${{ github.workspace }}/nanobind_example
       - name: Check ${{ matrix.os }} CPython>=3.12 wheels for stable ABI violations
         if: matrix.python-version >= 3.12
         run: |
           uv pip install abi3audit
-          uv build --wheel -o dist
-          uv run -m abi3audit dist/*.whl --verbose --summary
+          uv build --wheel
+          uv run --no-sync abi3audit dist/*.whl --verbose --summary
         shell: bash
         working-directory: ${{ github.workspace }}/nanobind_example

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -34,7 +34,6 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
       - name: Check out nanobind example repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -64,7 +64,7 @@ jobs:
           python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
         working-directory: ${{ github.workspace }}/nanobind_example
       - name: Check ${{ matrix.os }} CPython>=3.12 wheels for stable ABI violations
-        if: fromJSON(matrix.py) >= 3.12
+        if: ${{ fromJSON(matrix.py) >= 3.12 }}
         run: |
           python -m pip install --upgrade abi3audit
           python -m abi3audit dist/*.whl --verbose

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
@@ -51,7 +51,7 @@ jobs:
           uv venv --seed -p ${{ matrix.python-version }}
           source .venv/bin/activate
           uv pip install build
-          uv run -m build . -w
+          uv run --no-editable -m build . -w
           uv pip install --find-links=dist/ nanobind_example
           python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
         shell: bash

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -40,7 +40,8 @@ jobs:
           repository: wjakob/nanobind_example
           path: nanobind_example
           ref: bazel
-      - run: git apply ${{github.workspace }}/stubgen.patch
+      - name: Patch nanobind_example stubgen target
+        run: git apply ${{github.workspace }}/stubgen.patch
         working-directory: ${{ github.workspace }}/nanobind_example
 
       - name: Override nanobind_bazel pin in MODULE.bazel

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -47,10 +47,13 @@ jobs:
         run: python fixup_module_bazel.py ${{ github.workspace}}/nanobind_example
       - name: Build and test nanobind_example on ${{ matrix.os }}
         run: |
+          uv venv --seed -p ${{ matrix.python-version }}
+          source .venv/bin/activate
           uv pip install build
           uv run -m build . -w
           uv pip install --find-links=dist/ nanobind_example
           python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
+        shell: bash
         working-directory: ${{ github.workspace }}/nanobind_example
       - name: Check ${{ matrix.os }} CPython>=3.12 wheels for stable ABI violations
         if: matrix.python-version >= 3.12

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -52,6 +52,8 @@ jobs:
           repository: wjakob/nanobind_example
           path: nanobind_example
           ref: bazel
+      - run: git apply ${{github.workspace }}/stubgen.patch
+        working-directory: ${{ github.workspace }}/nanobind_example
 
       - name: Override nanobind_bazel pin in MODULE.bazel
         run: python fixup_module_bazel.py ${{ github.workspace}}/nanobind_example

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
@@ -53,7 +53,7 @@ jobs:
           uv run --no-sync -- python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
         working-directory: ${{ github.workspace }}/nanobind_example
       - name: Check ${{ matrix.os }} CPython>=3.12 wheels for stable ABI violations
-        if: matrix.python-version >= 3.12
+        if: ${{ contains(fromJSON('["3.12", "3.13"]'), matrix.python-version) }}
         run: |
           uv pip install abi3audit
           uv build --wheel

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -12,40 +12,28 @@ jobs:
   buildifier:
     name: Lint Bazel files with buildifier
     runs-on: ubuntu-latest
-    env:
-      PRE_COMMIT_HOME: "${{ github.workspace }}/.cache/pre-commit"
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python and dependencies
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-      - name: Install pre-commit
-        run: pip install --upgrade pre-commit
-      - name: Cache pre-commit tools
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.PRE_COMMIT_HOME }}
-          key: ${{ hashFiles('.pre-commit-config.yaml') }}-linter-cache
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - name: Run pre-commit checks
-        run: pre-commit run --all-files --verbose --show-diff-on-failure
+        run: uvx pre-commit run --all-files --verbose --show-diff-on-failure
   test:
-    name: Test nanobind_example on ${{ matrix.os }} w/ Python ${{ matrix.py }}
+    name: Test nanobind_example on ${{ matrix.os }} w/ Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        py: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.py }} on ${{ matrix.os }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.py }}
-      - run: python -m pip install build
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - name: Install Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
       - name: Check out nanobind example repo
         uses: actions/checkout@v4
         with:
@@ -59,14 +47,15 @@ jobs:
         run: python fixup_module_bazel.py ${{ github.workspace}}/nanobind_example
       - name: Build and test nanobind_example on ${{ matrix.os }}
         run: |
-          python -m build . -w
-          python -m pip install --find-links=dist/ nanobind_example
+          uv pip install build
+          uv run -m build . -w
+          uv pip install --find-links=dist/ nanobind_example
           python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
         working-directory: ${{ github.workspace }}/nanobind_example
       - name: Check ${{ matrix.os }} CPython>=3.12 wheels for stable ABI violations
-        if: ${{ fromJSON(matrix.py) >= 3.12 }}
+        if: matrix.python-version >= 3.12
         run: |
-          python -m pip install --upgrade abi3audit
-          python -m abi3audit dist/*.whl --verbose
+          uv pip install abi3audit
+          uv run -m abi3audit dist/*.whl --verbose --summary
         shell: bash
         working-directory: ${{ github.workspace }}/nanobind_example

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
       - name: Run pre-commit checks
         run: uvx pre-commit run --all-files --verbose --show-diff-on-failure
   test:
@@ -31,9 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
-      - name: Install Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
       - name: Check out nanobind example repo
         uses: actions/checkout@v4
         with:
@@ -48,16 +49,14 @@ jobs:
         run: python fixup_module_bazel.py ${{ github.workspace}}/nanobind_example
       - name: Build and test nanobind_example on ${{ matrix.os }}
         run: |
-          uv sync --no-install-project
-          uv build --wheel -o dist
-          uv pip install --no-index --find-links=dist/ nanobind_example
-          python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
-        shell: bash
+          uv sync --no-editable
+          uv run python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
         working-directory: ${{ github.workspace }}/nanobind_example
       - name: Check ${{ matrix.os }} CPython>=3.12 wheels for stable ABI violations
         if: matrix.python-version >= 3.12
         run: |
           uv pip install abi3audit
+          uv build --wheel -o dist
           uv run -m abi3audit dist/*.whl --verbose --summary
         shell: bash
         working-directory: ${{ github.workspace }}/nanobind_example

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -62,7 +62,7 @@ jobs:
           python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
         working-directory: ${{ github.workspace }}/nanobind_example
       - name: Check ${{ matrix.os }} CPython>=3.12 wheels for stable ABI violations
-        if: matrix.py >= 3.12
+        if: fromJSON(matrix.py) >= 3.12
         run: |
           python -m pip install --upgrade abi3audit
           python -m abi3audit dist/*.whl --verbose

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -48,11 +48,9 @@ jobs:
         run: python fixup_module_bazel.py ${{ github.workspace}}/nanobind_example
       - name: Build and test nanobind_example on ${{ matrix.os }}
         run: |
-          uv venv --seed -p ${{ matrix.python-version }}
-          source .venv/bin/activate
-          uv pip install build
-          uv run --no-editable -m build . -w
-          uv pip install --find-links=dist/ nanobind_example
+          uv sync --no-install-project
+          uv build --wheel -o dist
+          uv pip install --no-index --find-links=dist/ nanobind_example
           python -c "import nanobind_example; assert nanobind_example.add(1, 2) == 3"
         shell: bash
         working-directory: ${{ github.workspace }}/nanobind_example

--- a/stubgen.patch
+++ b/stubgen.patch
@@ -1,0 +1,13 @@
+diff --git a/src/BUILD b/src/BUILD
+index 5562dca..95e210e 100644
+--- a/src/BUILD
++++ b/src/BUILD
+@@ -20,6 +20,6 @@ nanobind_stubgen(
+     name = "nanobind_example_ext_stubgen",
+     module = ":nanobind_example_ext",
+     marker_file = "src/py.typed",
+-    output_directory = "src",
+-    recursive = True,
++#    output_directory = "src",
++#    recursive = True,
+ )


### PR DESCRIPTION
Currently, it's a string comparison, which means ">=" is checked by character. Hence, we invoke abi3audit even for Python 3.8 and 3.9, which is useless.

This might break if free-threading gets thrown into the mix, which carries a "t" suffix in its version, preventing integer casting.