### PR TITLE
Add alias forwarding internal `@nanobind` to users

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,6 +9,12 @@ exports_files([
     "stubgen_wrapper.py",
 ])
 
+alias(
+    name = "nanobind",
+    actual = "@nanobind",
+    visibility = ["//visibility:public"],
+)
+
 bool_flag(
     name = "minsize",
     build_setting_default = True,


### PR DESCRIPTION
This enables users to consume the internal nanobind library for their own purposes, exposing it as `@nanobind_bazel//:nanobind`.

Related to #48.