### PR TITLE
Use `rules_python` free-threading config settings

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -30,21 +30,6 @@ config_setting(
     flag_values = {":minsize": "False"},
 )
 
-bool_flag(
-    name = "free_threading",
-    build_setting_default = False,
-)
-
-config_setting(
-    name = "with_free_threading",
-    flag_values = {":free_threading": "True"},
-)
-
-config_setting(
-    name = "without_free_threading",
-    flag_values = {":free_threading": "False"},
-)
-
 string_flag(
     name = "py-limited-api",
     build_setting_default = "unset",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_python", version = "0.37.0")
+bazel_dep(name = "rules_python", version = "0.39.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 
 # Creates a `http_archive` for nanobind and robin-map.

--- a/helpers.bzl
+++ b/helpers.bzl
@@ -58,6 +58,6 @@ def extension_name(name):
 # Optionally add a define for free-threaded nanobind builds.
 def nb_free_threading():
     return select({
-        "@nanobind_bazel//:with_free_threading": ["NB_FREE_THREADED"],
-        "@nanobind_bazel//:without_free_threading": [],
+        "@rules_python//python/config_settings:is_py_freethreaded": ["NB_FREE_THREADED"],
+        "//conditions:default": [],
     })


### PR DESCRIPTION
Eliminates the need for custom settings, and another flag to set for consuming builds.

This requires a bump to rules_python v0.39.0, which introduced free-threading support.