### PR TITLE
Drop Python 3.8 and 3.9 from GitHub Actions test matrix

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv


### PR DESCRIPTION
That's per NumPy Python support policy, which considers Python versions only released within the last 48 months.

No updates to the stubgen wrapper yet, so that Python 3.8 should still work, though untested. I could run pyupgrade for 3.9 later to bump to Python 3.9 syntax, for example by adding a ruff job.