### PR TITLE
Bump to v2.4.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "nanobind_bazel",
-    version = "2.2.0",
+    version = "2.4.0",
     compatibility_level = 1,
 )
 

--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -17,12 +17,12 @@ def _internal_configure_extension_impl(_):
         urls = ["https://github.com/Tessil/robin-map/archive/refs/tags/v%s.tar.gz" % robin_map_version],
     )
 
-    nanobind_version = "2.2.0"
+    nanobind_version = "2.4.0"
     http_archive(
         name = "nanobind",
         build_file = "//:nanobind.BUILD",
         strip_prefix = "nanobind-%s" % nanobind_version,
-        integrity = "sha256-v7/H5XWfFmnk3bSHUrHdxWR9FDDpRhTW+GJt8dUI5lo=",
+        integrity = "sha256-uzXertfvrFAp7R4ziApBVjg1L3V9SSB6jmAT/vtsSac=",
         urls = ["https://github.com/wjakob/nanobind/archive/refs/tags/v%s.tar.gz" % nanobind_version],
     )
 


### PR DESCRIPTION
Includes a module update as well as a nanobind repo update.

No v2.3.0, since nanobind skipped over it by mistake.