### PR TITLE
Add Python 3.14 stable ABI support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/keith/pre-commit-buildifier
-      rev: 7.3.1.1
+      rev: 8.0.0
       hooks:
       -   id: buildifier
       -   id: buildifier-lint

--- a/BUILD
+++ b/BUILD
@@ -36,6 +36,7 @@ string_flag(
     values = [
         "cp312",
         "cp313",
+        "cp314",
         "unset",
     ],
 )
@@ -48,6 +49,11 @@ config_setting(
 config_setting(
     name = "cp313",
     flag_values = {":py-limited-api": "cp313"},
+)
+
+config_setting(
+    name = "cp314",
+    flag_values = {":py-limited-api": "cp314"},
 )
 
 config_setting(

--- a/helpers.bzl
+++ b/helpers.bzl
@@ -43,6 +43,7 @@ def py_limited_api():
     return select({
         "@nanobind_bazel//:cp312": ["Py_LIMITED_API=0x030C0000"],
         "@nanobind_bazel//:cp313": ["Py_LIMITED_API=0x030D0000"],
+        "@nanobind_bazel//:cp314": ["Py_LIMITED_API=0x030E0000"],
         "@nanobind_bazel//:pyunlimitedapi": [],
     })
 


### PR DESCRIPTION
Given as `@nanobind_bazel//:py-limited-api=cp314`. This enables builds with alpha/beta/rc CPython 3.14 toolchains targeting the stable ABI from that version onwards.