### PR TITLE
stubgen: Remove path fixup workaround

### DIFF
--- a/stubgen_wrapper.py
+++ b/stubgen_wrapper.py
@@ -122,13 +122,6 @@ def wrapper():
 
     main(args)
 
-    if "-O" in args:
-        from_path = os.path.join(
-            *modname.split(".")[1:-1], ".".join(modname.split(".")[:-1]) + ".pyi"
-        )
-        to_path = os.path.join(*modname.split(".")[1:]) + ".pyi"
-        shutil.move(bindir / from_path, bindir / to_path)
-
 
 if __name__ == "__main__":
     wrapper()


### PR DESCRIPTION
This was fixed in v2.5.0, so we can remove the path fixup section.