### PR TITLE
chore: Switch to non-native rules to maintain new Bazel compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/keith/pre-commit-buildifier
-      rev: 8.0.0
+      rev: 8.0.1
       hooks:
       -   id: buildifier
       -   id: buildifier-lint

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -19,6 +19,7 @@ load(
     "nb_common_opts",
     "nb_sizeopts",
 )
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 
 NANOBIND_COPTS = nb_common_opts() + nb_sizeopts()
@@ -68,8 +69,7 @@ def nanobind_extension(
         NANOBIND_DOMAIN = ["NB_DOMAIN={}".format(domain)]
     else:
         NANOBIND_DOMAIN = []
-
-    native.cc_binary(
+    cc_binary(
         name = name + ".so",
         srcs = srcs,
         copts = copts + NANOBIND_COPTS,
@@ -107,7 +107,7 @@ def nanobind_library(
         copts = [],
         deps = [],
         **kwargs):
-    native.cc_library(
+    cc_library(
         name = name,
         copts = copts + NANOBIND_COPTS,
         deps = deps + NANOBIND_DEPS,
@@ -252,7 +252,7 @@ def nanobind_test(
         copts = [],
         deps = [],
         **kwargs):
-    native.cc_test(
+    cc_test(
         name = name,
         copts = copts + NANOBIND_COPTS,
         deps = deps + NANOBIND_DEPS,

--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -14,6 +14,8 @@ load(
     "nb_stripopts",
     "py_limited_api",
 )
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_python//python:defs.bzl", "py_library")
 
 licenses(["notice"])
 

--- a/robin_map.BUILD
+++ b/robin_map.BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
This is important since native aliases to these rules will be removed eventually in newer Bazel versions.

The changeset is a result of autofixes by buildifier when bumped to v8.0.1.