### PR TITLE
Bump rules_cc and rules_python dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,8 +5,8 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_python", version = "0.39.0")
+bazel_dep(name = "rules_cc", version = "0.0.16")
+bazel_dep(name = "rules_python", version = "0.40.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 
 # Creates a `http_archive` for nanobind and robin-map.


### PR DESCRIPTION
This is necessary due to a yanked rules_cc version showing up in the dependency graph for Bazel 7.