### PR TITLE
Update to nanobind v2.6.1

### DIFF
--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -17,12 +17,12 @@ def _internal_configure_extension_impl(_):
         urls = ["https://github.com/Tessil/robin-map/archive/refs/tags/v%s.tar.gz" % robin_map_version],
     )
 
-    nanobind_version = "2.5.0"
+    nanobind_version = "2.6.1"
     http_archive(
         name = "nanobind",
         build_file = "//:nanobind.BUILD",
         strip_prefix = "nanobind-%s" % nanobind_version,
-        integrity = "sha256-rLLhmXxE8sefUQxm5/+fTKwFAun+J168evdXHoafjfA=",
+        integrity = "sha256-UZxt1WWBrW25qrgUEFwmZqBJEJZIfLOE3SAhb4DRopE=",
         urls = ["https://github.com/wjakob/nanobind/archive/refs/tags/v%s.tar.gz" % nanobind_version],
     )
 


### PR DESCRIPTION
Skips minor-version "0" because of a regression in nanobind, which ended up in v2.6.0 being yanked.