### PR TITLE
buildifier: Import cc_shared_library from proper submodule of rules_cc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/keith/pre-commit-buildifier
-      rev: 8.0.1
+      rev: 8.0.3
       hooks:
       -   id: buildifier
       -   id: buildifier-lint

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -19,6 +19,7 @@ load(
     "nb_common_opts",
     "nb_sizeopts",
 )
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 
@@ -138,7 +139,7 @@ def nanobind_shared_library(
             rule. For a comprehensive list, see the Bazel documentation at
             https://bazel.build/reference/be/c-cpp#cc_shared_library.
     """
-    native.cc_shared_library(
+    cc_shared_library(
         name = name,
         deps = deps + NANOBIND_DEPS,
         **kwargs


### PR DESCRIPTION
This is an autofix by the most recent buildifier.