### PR TITLE
chore: Bump robin-map to v1.4.0

### DIFF
--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -8,12 +8,12 @@ and patch the version and integrity parameter of the `http_archive`s below.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _internal_configure_extension_impl(_):
-    robin_map_version = "1.3.0"
+    robin_map_version = "1.4.0"
     http_archive(
         name = "robin_map",
         build_file = "//:robin_map.BUILD",
         strip_prefix = "robin-map-%s" % robin_map_version,
-        integrity = "sha256-qEJK07Cv/UxX7Sbw89iilgTw4fLvIIn0l/YUsclMcjY=",
+        integrity = "sha256-eTDb+WNKz8Amhth/YVwPTzMTWUgTC4kiMxwW2QoDJQw=",
         urls = ["https://github.com/Tessil/robin-map/archive/refs/tags/v%s.tar.gz" % robin_map_version],
     )
 


### PR DESCRIPTION
Mirrors the same bump in the nanobind repository.