### PR TITLE
chore: Bump typing-extensions to v4.13.2

### DIFF
--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -26,13 +26,13 @@ def _internal_configure_extension_impl(_):
         urls = ["https://github.com/wjakob/nanobind/archive/refs/tags/v%s.tar.gz" % nanobind_version],
     )
 
-    typing_extensions_version = "4.12.2"
+    typing_extensions_version = "4.13.2"
     http_archive(
         name = "pypi__typing_extensions",
         build_file = "//:typing_extensions.BUILD",
         strip_prefix = "typing_extensions-%s" % typing_extensions_version,
-        integrity = "sha256-Gn6tVcflWd1N7ohW46iLQSJav+HOjfV7fBORX+Eh/7g=",
-        urls = ["https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-%s.tar.gz" % typing_extensions_version],
+        integrity = "sha256-5sgSGb1on1GGXZ43KZHFQL2jOgN51Vc83bmjoj98qu8=",
+        urls = ["https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-%s.tar.gz" % typing_extensions_version],
     )
 
 internal_configure_extension = module_extension(implementation = _internal_configure_extension_impl)


### PR DESCRIPTION
Released on April 10, 2025.