### PR TITLE
Fix visibilities of top-level build flags and settings

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -129,6 +129,7 @@ selects.config_setting_group(
         ":cp313",
         ":cp314",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # A stable ABI build on Linux or Mac.
@@ -139,6 +140,7 @@ selects.config_setting_group(
         ":stable-abi",
         ":unix",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # An unlimited Python ABI build on Linux or Mac. Produces a regular .so file.
@@ -148,6 +150,7 @@ selects.config_setting_group(
         ":pyunlimitedapi",
         ":unix",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # Is the currently configured C++ compiler not MSVC?
@@ -159,6 +162,7 @@ selects.config_setting_group(
         "@rules_cc//cc/compiler:clang-cl",
         "@rules_cc//cc/compiler:mingw-gcc",
     ],
+    visibility = ["//visibility:public"],
 )
 
 selects.config_setting_group(

--- a/BUILD
+++ b/BUILD
@@ -18,16 +18,19 @@ alias(
 bool_flag(
     name = "minsize",
     build_setting_default = True,
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "with_sizeopts",
     flag_values = {":minsize": "True"},
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "without_sizeopts",
     flag_values = {":minsize": "False"},
+    visibility = ["//visibility:public"],
 )
 
 string_flag(
@@ -39,26 +42,31 @@ string_flag(
         "cp314",
         "unset",
     ],
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "cp312",
     flag_values = {":py-limited-api": "cp312"},
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "cp313",
     flag_values = {":py-limited-api": "cp313"},
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "cp314",
     flag_values = {":py-limited-api": "cp314"},
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "pyunlimitedapi",
     flag_values = {":py-limited-api": "unset"},
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -69,6 +77,7 @@ config_setting(
     values = {
         "compilation_mode": "opt",
     },
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -79,6 +88,7 @@ config_setting(
     values = {
         "compilation_mode": "opt",
     },
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -89,6 +99,7 @@ config_setting(
     values = {
         "compilation_mode": "opt",
     },
+    visibility = ["//visibility:public"],
 )
 
 selects.config_setting_group(
@@ -98,6 +109,7 @@ selects.config_setting_group(
         ":MacReleaseBuild",
         ":WindowsReleaseBuild",
     ],
+    visibility = ["//visibility:public"],
 )
 
 selects.config_setting_group(
@@ -106,6 +118,7 @@ selects.config_setting_group(
         "@platforms//os:linux",
         "@platforms//os:macos",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # Config setting indicating that stable ABI extension build was requested.
@@ -114,6 +127,7 @@ selects.config_setting_group(
     match_any = [
         ":cp312",
         ":cp313",
+        ":cp314",
     ],
 )
 
@@ -153,6 +167,7 @@ selects.config_setting_group(
         "@rules_cc//cc/compiler:msvc-cl",
         ":with_sizeopts",
     ],
+    visibility = ["//visibility:public"],
 )
 
 selects.config_setting_group(
@@ -161,4 +176,5 @@ selects.config_setting_group(
         ":nonmsvc",
         ":with_sizeopts",
     ],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Previously, nanobind_bazel implicitly relied on its top-level attributes being publicly visible, since the nanobind built in the module extension needs some of them to decide which options and defines to set for the build.

To fix, explicitly set visibilities on the used settings and flags. For simplicity, go with public visibility, since other downstream users might want to consume these attributes as well.

Closes #70.