### PR TITLE
Added `-fexceptions` and `-frtti` flags into nb_common_opts

### DIFF
--- a/helpers.bzl
+++ b/helpers.bzl
@@ -5,6 +5,7 @@ def nb_common_opts(mode = "user"):
         "-fPIC",
         "-fvisibility=hidden",
         "-fno-strict-aliasing",
+        "-fexceptions",
     ]
 
     if mode == "user":

--- a/helpers.bzl
+++ b/helpers.bzl
@@ -6,6 +6,7 @@ def nb_common_opts(mode = "user"):
         "-fvisibility=hidden",
         "-fno-strict-aliasing",
         "-fexceptions",
+        "-frtti",
     ]
 
     if mode == "user":


### PR DESCRIPTION
Currently, nanobind can only be compiled with exceptions and rtti flags ([here is the proof](https://nanobind.readthedocs.io/en/latest/faq.html#can-i-use-nanobind-without-rtti-or-c-exceptions)). By default these are on, but if I try to use my own toolchain with `-fno-exceptions` and `-fno-rtti` it breaks nanobind.

I suggest to enable rtti and exceptions explicitly, so it will override toolchain options and nanobind will compile anyway. This helped in my case, I hope it will help others too