### PR TITLE
fix(SABI): Use new `headers_abi3` target on Windows if available

### DIFF
--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -16,6 +16,7 @@ load(
 )
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:features.bzl", "features")
 
 licenses(["notice"])
 
@@ -50,10 +51,14 @@ cc_library(
             "src/*.h",
         ],
     ),
-    deps = [
-        "@robin_map",
-        "@rules_python//python/cc:current_py_cc_headers",
-    ],
+    deps = ["@robin_map"] + select(
+        {
+            "@nanobind_bazel//:stable-abi": [
+                "@rules_python//python/cc:current_py_cc_headers_abi3" if getattr(features, "headers_abi3", False) else "@rules_python//python/cc:current_py_cc_headers",
+            ],
+            "//conditions:default": ["@rules_python//python/cc:current_py_cc_headers"],
+        },
+    ),
 )
 
 py_library(


### PR DESCRIPTION
This is a backwards-compatible fix attempt for Windows stable ABI builds. To recap, until recently, Windows extension builds silently linked against the wrong lib file, causing lookup errors when running a stable ABI extension on a Python version different from the one with which the extension was built.

The fix is backwards-compatible because it decays gracefully into the old (buggy) behavior if we do not detect the "headers_abi3" feature in `rules_python`, which marks the inclusion of the correct ABI3 headers target.

For Mac and Linux, this is a no-op, since they never had trouble with stable ABI extensions to begin with.

---------------------------

Fixes #72. Backstory is available there, credit for the feature check goes to @rickeylev in https://github.com/bazel-contrib/rules_python/pull/3274#issuecomment-3320072575.