### PR TITLE
build(nanobind): Set `NB_BUILD` and `NB_SHARED` macros for libnanobind

### DIFF
--- a/nanobind.BUILD
+++ b/nanobind.BUILD
@@ -44,7 +44,10 @@ cc_library(
         ],
         "//conditions:default": [],
     }) + nb_stripopts(),
-    local_defines = maybe_compact_asserts(),
+    local_defines = [
+        "NB_BUILD=1",
+        "NB_SHARED=1",
+    ] + maybe_compact_asserts(),
     textual_hdrs = glob(
         [
             "include/**/*.h",


### PR DESCRIPTION
This way, libraries can consume symbols from dynamically linked libnanobinds, i.e. shared library builds of nanobind.

Closes #81. This hopefully also fixes LLVM build failures seen in https://github.com/llvm/llvm-project/pull/169306, when released on the BCR.

Maybe someone with more experience can explain if these definitions impact static linkage of nanobind.