### PR TITLE
deps(bzlmod): Bump rules_python and rules_cc

### DIFF
--- a/stubgen_wrapper.py
+++ b/stubgen_wrapper.py
@@ -39,7 +39,7 @@ def convert_path_to_module(path: Union[str, os.PathLike]):
     Example:
         For a shared lib pkg/foo.so, this returns pkg.foo.
     """
-    pp = Path(path).relative_to(RLOCATION_ROOT)
+    pp = Path(path)
     # this trick strips up to two extensions from the file name.
     # Since possible extensions at this point are
     # .so, .abi3.so, and .pyd, this path always gives us the


### PR DESCRIPTION
~~This brings with it a small change in the module import sourcing for stubgen, which now has to be given relative to the Python runfiles' `_main` directory.~~

Spoke too soon - I observed this with rules_python v1.7.0 on my local machine. I'll investigate further.